### PR TITLE
Fix command window

### DIFF
--- a/compile.hxml
+++ b/compile.hxml
@@ -34,7 +34,7 @@
 
 --next
 -D compileMV
--js games/mv/js/plugins/Luna_Quit2Desktop.js
+-js games/mv/js/plugins/Luna_Quit2DesktopMV.js
 
 --next
 -js games/mz/js/plugins/Luna_Quit2Desktop.js

--- a/dist/Luna_Quit2Desktop.js
+++ b/dist/Luna_Quit2Desktop.js
@@ -2,7 +2,7 @@
  *
  *  Luna_Quit2Desktop.js
  * 
- *  Build Date: 9/16/2020
+ *  Build Date: 9/17/2020
  * 
  *  Made with LunaTea -- Haxe
  *
@@ -75,6 +75,7 @@ SOFTWARE
       Main.Params = utils_Parse.parseParameters(
         PluginManager.parameters("Luna_Quit2Desktop")
       );
+
       if (Main.Params.showOnTitle) {
         let oldMakeCommandList = Window_TitleCommand.prototype.makeCommandList;
         Window_TitleCommand.prototype.makeCommandList = function () {
@@ -136,6 +137,7 @@ SOFTWARE
             self.calcWindowHeight(2, true)
           )
         );
+
         self._confirmWindow = confirmWindow;
         confirmWindow.setHandler("ok", self.onConfirm.bind(self));
         confirmWindow.close();
@@ -143,6 +145,7 @@ SOFTWARE
       };
       Scene_GameEnd.prototype.quit2desktop = function () {
         let self = this;
+        self._commandWindow.close();
         self._helpWindow.show();
         self._helpWindow.open();
         self._helpWindow.setText("Are you sure you want to exit to desktop?");
@@ -157,6 +160,7 @@ SOFTWARE
           SceneManager.exit();
         }
         self._helpWindow.close();
+        self._commandWindow.open();
         return self._commandWindow.activate();
       };
     }

--- a/dist/Luna_Quit2DesktopMV.js
+++ b/dist/Luna_Quit2DesktopMV.js
@@ -2,7 +2,7 @@
  *
  *  Luna_Quit2DesktopMV.js
  * 
- *  Build Date: 9/16/2020
+ *  Build Date: 9/17/2020
  * 
  *  Made with LunaTea -- Haxe
  *
@@ -73,8 +73,9 @@ SOFTWARE
   class Main {
     static main() {
       Main.Params = utils_Parse.parseParameters(
-        PluginManager.parameters("Luna_Quit2Desktop")
+        PluginManager.parameters("Luna_Quit2DesktopMV")
       );
+
       if (Main.Params.showOnTitle) {
         let oldMakeCommandList = Window_TitleCommand.prototype.makeCommandList;
         Window_TitleCommand.prototype.makeCommandList = function () {
@@ -138,6 +139,7 @@ SOFTWARE
       };
       Scene_GameEnd.prototype.quit2desktop = function () {
         let self = this;
+        self._commandWindow.close();
         self._helpWindow.show();
         self._helpWindow.open();
         self._helpWindow.setText("Are you sure you want to exit to desktop?");
@@ -152,6 +154,7 @@ SOFTWARE
           SceneManager.exit();
         }
         self._helpWindow.close();
+        self._commandWindow.open();
         return self._commandWindow.activate();
       };
     }

--- a/src/scenes/Scene_GameEnd.hx
+++ b/src/scenes/Scene_GameEnd.hx
@@ -61,6 +61,7 @@ class Scene_GameEnd {
   public static inline function quit2desktop() {
     Fn.setPrProp(RmScene_GameEnd, 'quit2desktop', () -> {
       var self: Dynamic = Fn.self;
+      self._commandWindow.close();
       self._helpWindow.show();
       self._helpWindow.open();
       self._helpWindow.setText('Are you sure you want to exit to desktop?');
@@ -80,6 +81,7 @@ class Scene_GameEnd {
       }
 
       self._helpWindow.close();
+      self._commandWindow.open();
       self._commandWindow.activate();
     });
   }


### PR DESCRIPTION
The command window would appear below the confirmation window, and in MV the command window will grow as large as the commands it contains. 
This fix hides the command window when the confirmation window opens.